### PR TITLE
feat: generate_tag_images now uses tag_id to generate a qr code with …

### DIFF
--- a/tagandtake/staticfiles/css/email_styles.css
+++ b/tagandtake/staticfiles/css/email_styles.css
@@ -1,0 +1,81 @@
+body {
+    font-family: Roboto, Arial, sans-serif;
+    background-color: #f8f8f8;
+    color: #333333;
+    margin: 0;
+    padding: 0;
+}
+.container {
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 20px;
+    background-color: #ffffff;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+}
+.header {
+    text-align: center;
+    padding: 20px 0;
+    border-bottom: 1px solid #eaeaec;
+}
+.header img {
+    width: 200px; 
+}
+.content {
+    padding: 20px;
+    text-align: center;
+}
+.content h1, .content h2 {
+    color: #1a1a1a;
+    font-size: 28px;
+    margin-bottom: 20px;
+    font-weight: 700;
+}
+.content p {
+    font-size: 16px;
+    line-height: 1.5;
+    margin-bottom: 20px;
+}
+.button {
+    display: inline-block;
+    padding: 12px 24px;
+    margin: 20px 0;
+    background-color: #426B1F;
+    color: #ffffff;
+    text-decoration: none;
+    border-radius: 5px;
+    font-size: 16px;
+    font-weight: 600;
+}
+.footer {
+    text-align: center;
+    padding: 20px 0;
+    border-top: 1px solid #eaeaec;
+    font-size: 14px;
+    color: #888888;
+}
+.pin {
+    display: inline-block;
+    padding: 10px 20px;
+    margin: 20px 0;
+    font-size: 24px;
+    font-weight: bold;
+    color: #ffffff;
+    background-color: #426B1F;
+    border-radius: 5px;
+}
+@media (max-width: 600px) {
+    .container {
+        padding: 10px;
+    }
+    .header img {
+        width: 150px
+    }
+    .content {
+        padding: 10px;
+    }
+    .button {
+        width: 100%;
+        box-sizing: border-box;
+    }
+}


### PR DESCRIPTION
Ples review:
https://github.com/Tag-Take/tagandtake-backend/issues/29

Note:
- I have additionally changed the other static methods where generate_tag_image is called to prevent these error'ing, could these be reviewed as well please?

Main concerns:
- Is the text bleeding into the QR code image? I would've thought the default size is small enough that there's no issue, otherwise I think I need to increase the border
- Did I reference the tag.id correctly as an argument in the instances where generate_tag_image is called?